### PR TITLE
[#27] (이메일) 임시 비밀번호 예외 추가 작성

### DIFF
--- a/src/main/java/dev/linkcentral/common/exception/DuplicateEmailException.java
+++ b/src/main/java/dev/linkcentral/common/exception/DuplicateEmailException.java
@@ -1,5 +1,8 @@
 package dev.linkcentral.common.exception;
 
+/**
+ * 중복된 이메일 예외.
+ */
 public class DuplicateEmailException extends RuntimeException {
     public DuplicateEmailException(String message) {
         super(message);

--- a/src/main/java/dev/linkcentral/common/exception/MemberEmailNotFoundException.java
+++ b/src/main/java/dev/linkcentral/common/exception/MemberEmailNotFoundException.java
@@ -1,0 +1,10 @@
+package dev.linkcentral.common.exception;
+
+/**
+ * 회원 이메일을 찾을 수 없을 경우 예외
+ */
+public class MemberEmailNotFoundException extends RuntimeException {
+    public MemberEmailNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/dev/linkcentral/database/entity/Member.java
+++ b/src/main/java/dev/linkcentral/database/entity/Member.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 import java.io.Serializable;

--- a/src/main/java/dev/linkcentral/database/repository/MemberRepository.java
+++ b/src/main/java/dev/linkcentral/database/repository/MemberRepository.java
@@ -12,9 +12,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByNicknameAndDeletedFalse(String nickname);
 
+    Optional<Member> findByEmailAndDeletedFalse(String nickname);
+
     Optional<Member> findByNicknameAndDeletedFalse(String nickname);
 
-    Optional<Member> findByEmailAndDeletedFalse(String email);
+    Optional<Member> findByEmailAndNameAndDeletedFalse(String email, String name);
 
     @Query("select count(m) from Member m where m.email = :email and m.deleted = false")
     Long countByEmailIgnoringDeleted(@Param("email") String email);

--- a/src/main/java/dev/linkcentral/service/MemberService.java
+++ b/src/main/java/dev/linkcentral/service/MemberService.java
@@ -2,6 +2,7 @@ package dev.linkcentral.service;
 
 import dev.linkcentral.common.exception.DuplicateEmailException;
 import dev.linkcentral.common.exception.DuplicateNicknameException;
+import dev.linkcentral.common.exception.MemberEmailNotFoundException;
 import dev.linkcentral.common.exception.MemberRegistrationException;
 import dev.linkcentral.database.entity.Member;
 import dev.linkcentral.database.repository.MemberRepository;
@@ -73,14 +74,21 @@ public class MemberService {
     }
 
     public boolean isNicknameDuplicated(String nickname) {
-        return memberRepository.existsByNicknameAndDeletedFalse(nickname);
+        boolean isDuplicated = memberRepository.existsByNicknameAndDeletedFalse(nickname);
+
+        if (isDuplicated) {
+            throw new DuplicateNicknameException("닉네임이 중복되었습니다.: " + nickname);
+        }
+        return isDuplicated;
     }
 
     public boolean userEmailCheck(String userEmail, String userName) {
-        Optional<Member> member = memberRepository.findByEmailAndDeletedFalse(userEmail);
-        String memberName = member.get().getName();
+        Optional<Member> member = memberRepository.findByEmailAndNameAndDeletedFalse(userEmail, userName);
 
-        return memberName.equals(userName);
+        if (!member.isPresent()) {
+            throw new MemberEmailNotFoundException("유저의 이메일을 찾을 수 없습니다.");
+        }
+        return true;
     }
 
     /**
@@ -178,5 +186,4 @@ public class MemberService {
         }
         return false;
     }
-
 }


### PR DESCRIPTION
## 요약
임시 비밀번호 발급 시 예외 처리를 추가하여 사용자 인증 절차를 강화했습니다. 
특히, 회원의 이메일을 찾을 수 없을 경우와 닉네임 및 이름이 일치하지 않을 때 
발생하는 예외를 처리하는 로직을 구현했습니다.

## 더 자세히
- 사용자의 이메일을 데이터베이스에서 찾을 수 없는 경우에 대한 예외를 생성하였습니다.
- 임시 비밀번호 발급 시 닉네임과 이름이 모두 일치해야 하며, 이를 검증하는 쿼리를 작성하였습니다.
- 불필요한 임포트를 제거하고, 주석을 추가하여 코드의 가독성을 높였습니다.

## 체크리스트
- [X] 이메일 찾기 예외 처리가 정상적으로 작동하는지 테스트
- [X] 닉네임 및 이름 일치 검사 로직이 정확하게 구현되었는지 확인
- [X] 코드 정리가 적절히 이루어졌는지 검토
- [X] 관련 테스트 코드를 작성하여 기능 확인