### PR TITLE
[#37] 게시글 글목록 기능 구현

### DIFF
--- a/src/main/java/dev/linkcentral/presentation/ArticleController.java
+++ b/src/main/java/dev/linkcentral/presentation/ArticleController.java
@@ -5,7 +5,10 @@ import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @Slf4j
@@ -25,5 +28,12 @@ public class ArticleController {
         log.info("info articleSaveDTO={}", articleDTO);
         articleService.save(articleDTO);
         return "/home";
+    }
+
+    @GetMapping("/")
+    public String findAll(Model model) {
+        List<ArticleRequestDTO> articleList = articleService.findAll();
+        model.addAttribute("articleList", articleList);
+        return "/articles/list";
     }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -6,6 +6,9 @@ import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ArticleService {
@@ -15,5 +18,15 @@ public class ArticleService {
     public void save(ArticleRequestDTO articleDTO) {
         Article articleEntity = Article.toSaveEntity(articleDTO);
         articleRepository.save(articleEntity);
+    }
+
+    public List<ArticleRequestDTO> findAll() {
+        List<Article> articleEntityList = articleRepository.findAll();
+        List<ArticleRequestDTO> articleDTOList = new ArrayList<>();
+
+        for (Article articleEntity : articleEntityList) {
+            articleDTOList.add(ArticleRequestDTO.toArticleDTO(articleEntity));
+        }
+        return articleDTOList;
     }
 }

--- a/src/main/webapp/WEB-INF/views/articles/list.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/list.jsp
@@ -1,0 +1,35 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>list</title>
+</head>
+<body>
+<table>
+  <tr>
+    <th>id</th>
+    <th>writer</th>
+    <th>title</th>
+    <th>date</th>
+    <th>hits</th>
+  </tr>
+  <c:forEach items="${articleList}" var="article">
+    <tr>
+      <td><c:out value="${article.id}"/></td>
+
+      <td><c:out value="${article.writer}"/></td>
+
+      <td><a href="<c:url value='/article/${article.id}'/>"><c:out value="${article.title}"/></a></td>
+
+      <td><c:out value="${article.createdAt}"/></td>
+
+        <%--조회수, 좋아요 추가하기--%>
+    </tr>
+  </c:forEach>
+</table>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -68,6 +68,10 @@
         function studyRecruitmentArticle() {
             window.location.href = "/api/v1/article/save";
         }
+
+        function studyRecruitmentArticleList() {
+            window.location.href = "/article/";
+        }
     </script>
 
 </head>
@@ -97,8 +101,9 @@
 
 
 
-
 <button onclick="studyRecruitmentArticle()">스터디 모집 게시판 글등록</button>
+
+<button onclick="studyRecruitmentArticleList()">스터디 모집 게시판 글목록</button>
 
 
 </body>


### PR DESCRIPTION
## 요약
게시글 목록 기능을 구현하여 사용자가 게시판의 모든 게시글을 볼 수 있도록 했습니다. 
이 기능에는 페이지네이션을 적용하여 게시글을 페이지별로 나누어 보여주는 기능도 포함되어 있습니다.

## 더 자세히
- 사용자가 게시글을 한 눈에 볼 수 있는 목록 페이지와, 해당 데이터를 제공하는 API를 구현했습니다.
- 사용자의 편의를 위해 게시글 목록을 페이지별로 나누어 보여주는 페이지네이션 기능을 추가했습니다.
- 게시글 목록을 불러오는 API에 페이지네이션을 지원하도록 수정했습니다.

## 체크리스트
- [X] 게시글 목록 페이지 및 API가 정상적으로 작동하는지 확인
- [X] 페이지네이션 기능이 올바르게 구현되었는지 테스트
- [X] API가 페이지네이션을 정확하게 지원하는지 검증