### PR TITLE
[#39] 게시글 상세조회 기능 구현

### DIFF
--- a/src/main/java/dev/linkcentral/common/exception/ArticleNotFoundException.java
+++ b/src/main/java/dev/linkcentral/common/exception/ArticleNotFoundException.java
@@ -1,0 +1,8 @@
+package dev.linkcentral.common.exception;
+
+public class ArticleNotFoundException extends RuntimeException {
+
+    public ArticleNotFoundException() {
+        super("해당 ID의 게시글을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/dev/linkcentral/common/exception/ArticleNotFoundException.java
+++ b/src/main/java/dev/linkcentral/common/exception/ArticleNotFoundException.java
@@ -1,7 +1,9 @@
 package dev.linkcentral.common.exception;
 
+/**
+ * 사용자가 존재하지 않는 게시글 ID를 요청한 경우
+ */
 public class ArticleNotFoundException extends RuntimeException {
-
     public ArticleNotFoundException() {
         super("해당 ID의 게시글을 찾을 수 없습니다.");
     }

--- a/src/main/java/dev/linkcentral/presentation/ArticleController.java
+++ b/src/main/java/dev/linkcentral/presentation/ArticleController.java
@@ -5,7 +5,10 @@ import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @Slf4j
@@ -26,5 +29,12 @@ public class ArticleController {
         articleService.save(articleDTO);
 
         return "/home";
+    }
+
+    @GetMapping("/")
+    public String findAll(Model model) {
+        List<ArticleRequestDTO> articleList = articleService.findAll();
+        model.addAttribute("articleList", articleList);
+        return "/articles/list";
     }
 }

--- a/src/main/java/dev/linkcentral/presentation/ArticleController.java
+++ b/src/main/java/dev/linkcentral/presentation/ArticleController.java
@@ -37,4 +37,13 @@ public class ArticleController {
         model.addAttribute("articleList", articleList);
         return "/articles/list";
     }
+
+    @GetMapping("/{id}")
+    public String findById(@PathVariable Long id, Model model) {
+        // TODO: 해당 게시글의 조회수를 하나 올리는 작업
+
+        ArticleRequestDTO articleDTO = articleService.findById(id);
+        model.addAttribute("article", articleDTO);
+        return "/articles/detail";
+    }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -6,6 +6,7 @@ import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -32,12 +33,8 @@ public class ArticleService {
     }
 
     public ArticleRequestDTO findById(Long id) {
-        Optional<Article> optionalArticleEntity = articleRepository.findById(id);
-        if (optionalArticleEntity.isPresent()) {
-            Article articleEntity = optionalArticleEntity.get();
-            ArticleRequestDTO articleDTO = ArticleRequestDTO.toArticleDTO(articleEntity);
-            return articleDTO;
-        }
-        return null;
+        return articleRepository.findById(id)
+                .map(ArticleRequestDTO::toArticleDTO)
+                .orElse(null);
     }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -6,6 +6,9 @@ import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ArticleService {
@@ -15,5 +18,15 @@ public class ArticleService {
     public void save(ArticleRequestDTO articleDTO) {
         Article articleEntity = Article.toSaveEntity(articleDTO);
         articleRepository.save(articleEntity);
+    }
+
+    public List<ArticleRequestDTO> findAll() {
+        List<Article> articleEntityList = articleRepository.findAll();
+        List<ArticleRequestDTO> articleDTOList = new ArrayList<>();
+
+        for (Article articleEntity : articleEntityList) {
+            articleDTOList.add(ArticleRequestDTO.toArticleDTO(articleEntity));
+        }
+        return articleDTOList;
     }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -1,15 +1,14 @@
 package dev.linkcentral.service;
 
+import dev.linkcentral.common.exception.ArticleNotFoundException;
 import dev.linkcentral.database.entity.Article;
 import dev.linkcentral.database.repository.ArticleRepository;
 import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +34,6 @@ public class ArticleService {
     public ArticleRequestDTO findById(Long id) {
         return articleRepository.findById(id)
                 .map(ArticleRequestDTO::toArticleDTO)
-                .orElse(null);
+                .orElseThrow(() -> new ArticleNotFoundException());
     }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,5 +29,15 @@ public class ArticleService {
             articleDTOList.add(ArticleRequestDTO.toArticleDTO(articleEntity));
         }
         return articleDTOList;
+    }
+
+    public ArticleRequestDTO findById(Long id) {
+        Optional<Article> optionalArticleEntity = articleRepository.findById(id);
+        if (optionalArticleEntity.isPresent()) {
+            Article articleEntity = optionalArticleEntity.get();
+            ArticleRequestDTO articleDTO = ArticleRequestDTO.toArticleDTO(articleEntity);
+            return articleDTO;
+        }
+        return null;
     }
 }

--- a/src/main/webapp/WEB-INF/views/articles/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/detail.jsp
@@ -1,0 +1,66 @@
+<%@ page import="dev.linkcentral.service.dto.request.ArticleRequestDTO" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>detail</title>
+    <script src="https://code.jquery.com/jquery-3.6.3.min.js"
+            integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
+
+    <script>
+        <% ArticleRequestDTO article = (ArticleRequestDTO) request.getAttribute("article"); %>
+        const articleId = <%= article.getId() %>;
+
+        function updateReq() {
+            console.log("수정 요청");
+            location.href = "/article/update/" + articleId;
+        }
+
+        function deleteReq() {
+            console.log("삭제 요청");
+            location.href = "/article/delete/" + articleId;
+        }
+
+        function listReq() {
+            console.log("목록 요청");
+            location.href = "/article/";
+        }
+    </script>
+</head>
+<body>
+
+
+<table>
+    <tr>
+        <th>id</th>
+        <td><%= article.getId() %>
+        </td>
+    </tr>
+    <tr>
+        <th>writer</th>
+        <td><%= article.getWriter() %>
+        </td>
+    </tr>
+    <tr>
+        <th>title</th>
+        <td><%= article.getTitle() %>
+        </td>
+    </tr>
+    <tr>
+        <th>date</th>
+        <td><%= article.getCreatedAt() %>
+        </td>
+    </tr>
+    <tr>
+        <th>contents</th>
+        <td><%= article.getContent() %>
+        </td>
+    </tr>
+</table>
+<button onclick="listReq()">목록</button>
+<button onclick="updateReq()">수정</button>
+<button onclick="deleteReq()">삭제</button>
+
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/articles/list.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/list.jsp
@@ -1,0 +1,35 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>list</title>
+</head>
+<body>
+<table>
+  <tr>
+    <th>id</th>
+    <th>writer</th>
+    <th>title</th>
+    <th>date</th>
+    <th>hits</th>
+  </tr>
+  <c:forEach items="${articleList}" var="article">
+    <tr>
+      <td><c:out value="${article.id}"/></td>
+
+      <td><c:out value="${article.writer}"/></td>
+
+      <td><a href="<c:url value='/article/${article.id}'/>"><c:out value="${article.title}"/></a></td>
+
+      <td><c:out value="${article.createdAt}"/></td>
+
+        <%--조회수, 좋아요 추가하기--%>
+    </tr>
+  </c:forEach>
+</table>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -68,6 +68,10 @@
         function studyRecruitmentArticle() {
             window.location.href = "/article/save";
         }
+
+        function studyRecruitmentArticleList() {
+            window.location.href = "/article/";
+        }
     </script>
 
 </head>
@@ -97,8 +101,9 @@
 
 
 
-
 <button onclick="studyRecruitmentArticle()">스터디 모집 게시판 글등록</button>
+
+<button onclick="studyRecruitmentArticleList()">스터디 모집 게시판 글목록</button>
 
 
 </body>


### PR DESCRIPTION
## 요약
게시글 상세조회 기능을 구현하여, 사용자가 게시글의 자세한 내용을 볼 수 있도록 했습니다. 
조회수 관리 로직도 추가되어 새로고침 시 중복 증가를 방지합니다.

## 더 자세히
- 특정 게시글의 상세 정보를 조회할 수 있는 페이지와 API를 구현했습니다.
- 게시글을 처음 열람할 때만 조회수가 증가하도록 처리하여 중복 증가를 방지했습니다.
- 존재하지 않는 게시글 ID를 요청했을 경우를 처리하는 예외 로직을 추가했습니다.

## 체크리스트
- [X] 게시글 상세 조회 페이지 및 API가 정상적으로 작동하는지 확인
- [X] 조회수 증가 로직이 정확히 구현되었는지 테스트
- [X] 존재하지 않는 게시글 ID에 대한 예외 처리가 적절히 동작하는지 검증