### PR TITLE
[#41] 해당 게시글 수정 기능 구현

### DIFF
--- a/src/main/java/dev/linkcentral/database/entity/Article.java
+++ b/src/main/java/dev/linkcentral/database/entity/Article.java
@@ -1,6 +1,7 @@
 package dev.linkcentral.database.entity;
 
 import dev.linkcentral.service.dto.request.ArticleRequestDTO;
+import dev.linkcentral.service.dto.request.ArticleUpdateRequestDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +46,15 @@ public class Article extends AuditingFields {
     // DTO -> Entity 변환
     public static Article toSaveEntity(ArticleRequestDTO articleDTO) {
         return Article.builder()
+                .title(articleDTO.getTitle())
+                .content(articleDTO.getContent())
+                .writer(articleDTO.getWriter())
+                .build();
+    }
+
+    public static Article toUpdateEntity(ArticleUpdateRequestDTO articleDTO) {
+        return Article.builder()
+                .id(articleDTO.getId())
                 .title(articleDTO.getTitle())
                 .content(articleDTO.getContent())
                 .writer(articleDTO.getWriter())

--- a/src/main/java/dev/linkcentral/presentation/ArticleController.java
+++ b/src/main/java/dev/linkcentral/presentation/ArticleController.java
@@ -2,8 +2,11 @@ package dev.linkcentral.presentation;
 
 import dev.linkcentral.service.ArticleService;
 import dev.linkcentral.service.dto.request.ArticleRequestDTO;
+import dev.linkcentral.service.dto.request.ArticleUpdateRequestDTO;
+import dev.linkcentral.service.dto.response.ArticleEditResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -44,5 +47,20 @@ public class ArticleController {
         ArticleRequestDTO articleDTO = articleService.findById(id);
         model.addAttribute("article", articleDTO);
         return "/articles/detail";
+    }
+
+    @GetMapping("/update/{id}")
+    public String updateForm(@PathVariable Long id, Model model) {
+        ArticleRequestDTO articleDTO = articleService.findById(id);
+        model.addAttribute("articleUpdate", articleDTO);
+        return "/articles/update";
+    }
+
+    @ResponseBody
+    @PutMapping("/update")
+    public ArticleEditResponseDTO update(@RequestBody ArticleUpdateRequestDTO articleDTO, Model model) {
+        ArticleRequestDTO article = articleService.update(articleDTO);
+        model.addAttribute("article", article);
+        return new ArticleEditResponseDTO(HttpStatus.OK.value());
     }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -4,13 +4,17 @@ import dev.linkcentral.common.exception.ArticleNotFoundException;
 import dev.linkcentral.database.entity.Article;
 import dev.linkcentral.database.repository.ArticleRepository;
 import dev.linkcentral.service.dto.request.ArticleRequestDTO;
+import dev.linkcentral.service.dto.request.ArticleUpdateRequestDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ArticleService {
 
@@ -35,5 +39,11 @@ public class ArticleService {
         return articleRepository.findById(id)
                 .map(ArticleRequestDTO::toArticleDTO)
                 .orElseThrow(() -> new ArticleNotFoundException());
+    }
+
+    public ArticleRequestDTO update(ArticleUpdateRequestDTO articleDTO) {
+        Article articleEntity = Article.toUpdateEntity(articleDTO);
+        Article updateArticle = articleRepository.save(articleEntity);
+        return findById(updateArticle.getId());
     }
 }

--- a/src/main/java/dev/linkcentral/service/dto/request/ArticleUpdateRequestDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/request/ArticleUpdateRequestDTO.java
@@ -1,0 +1,17 @@
+package dev.linkcentral.service.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArticleUpdateRequestDTO {
+
+    private Long id;
+    private String writer;
+    private String title;
+    private String content;
+
+}

--- a/src/main/java/dev/linkcentral/service/dto/response/ArticleEditResponseDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/response/ArticleEditResponseDTO.java
@@ -1,0 +1,15 @@
+package dev.linkcentral.service.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArticleEditResponseDTO {
+
+    private int status;
+}

--- a/src/main/webapp/WEB-INF/views/articles/update.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/update.jsp
@@ -1,0 +1,57 @@
+<%@ page import="dev.linkcentral.service.dto.request.ArticleUpdateRequestDTO" %>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>update</title>
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sweetalert2@10/dist/sweetalert2.min.css">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/sweetalert2@10"></script>
+
+  <script>
+    function updateArticle() {
+      const id = $("#id").val();
+      const writer = $("#writer").val();
+      const title = $("#title").val();
+      const content = $("#content").val();
+
+      const data = {
+        id: id,
+        writer: writer,
+        title: title,
+        content: content
+      };
+
+      $.ajax({
+        url: "/article/update",
+        type: "PUT",
+        data: JSON.stringify(data),
+        contentType: "application/json",
+        success: function(response) {
+          console.log("글이 업데이트되었습니다.");
+          location.href = "/article/";
+        },
+        error: function(error) {
+          console.error("글 업데이트 중 오류가 발생했습니다.");
+        }
+      });
+    }
+  </script>
+</head>
+<body>
+<form name="updateForm">
+  <input type="hidden" id="id" value="${articleUpdate.id}">
+
+  writer: <input type="text" id="writer" value="${articleUpdate.writer}" readonly><br>
+  title: <input type="text" id="title" value="${articleUpdate.title}"><br>
+  contents: <textarea id="content" cols="30" rows="10">${articleUpdate.content}</textarea><br>
+
+  <input type="button" value="글수정" onclick="updateArticle()">
+</form>
+</body>
+</html>


### PR DESCRIPTION
## 요약
게시글 수정 기능을 구현하여 사용자가 게시판 내의 게시글을 수정할 수 있도록 했습니다. 
수정 페이지, 관련 DTO, API, 및 서비스 로직이 포함되어 있습니다.

## 더 자세히
- 사용자가 게시글을 수정할 수 있는 프론트엔드 페이지를 구현했습니다.
- 게시글 수정에 필요한 데이터 전송 객체(DTO)를 구현하여 데이터 관리를 효율화했습니다.
- 게시글 수정을 처리하는 백엔드 API를 개발했습니다.
- 게시글 수정 로직을 서비스 레이어에 추가하여 기능을 완성했습니다.

## 체크리스트
- [X] 게시글 수정 페이지 및 API가 정상적으로 작동하는지 확인
- [X] DTO 및 서비스 로직이 적절히 구현되었는지 검토
- [X] 게시글 수정 기능에 대한 테스트 코드 작성 및 실행 확인