### PR TITLE
[#46] 게시판 페이징 기능 구현

### DIFF
--- a/src/main/java/dev/linkcentral/presentation/ArticleController.java
+++ b/src/main/java/dev/linkcentral/presentation/ArticleController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -70,10 +71,11 @@ public class ArticleController {
         return new ArticleEditResponseDTO(HttpStatus.OK.value());
     }
 
-    @GetMapping("/delete/{id}")
-    public String delete(@PathVariable Long id) {
+    @DeleteMapping("/delete/{id}")
+    @ResponseBody
+    public ResponseEntity<String> delete(@PathVariable Long id) {
         articleService.delete(id);
-        return "redirect:/api/v1/article/";
+        return ResponseEntity.ok().body("성공적으로 삭제되었습니다.");
     }
 
     @GetMapping("/paging")

--- a/src/main/java/dev/linkcentral/presentation/ArticleController.java
+++ b/src/main/java/dev/linkcentral/presentation/ArticleController.java
@@ -45,11 +45,13 @@ public class ArticleController {
     }
 
     @GetMapping("/{id}")
-    public String findById(@PathVariable Long id, Model model) {
+    public String findById(@PageableDefault(page = 1) Pageable pageable,
+                           @PathVariable Long id, Model model) {
         // TODO: 해당 게시글의 조회수를 하나 올리는 작업
 
         ArticleRequestDTO articleDTO = articleService.findById(id);
         model.addAttribute("article", articleDTO);
+        model.addAttribute("page", pageable.getPageNumber());
         return "/articles/detail";
     }
 

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +53,7 @@ public class ArticleService {
         return findById(updateArticle.getId());
     }
 
+    @Transactional
     public void delete(Long id) {
         articleRepository.deleteById(id);
     }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -17,20 +17,21 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 
-
-
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
 
+    @Transactional
     public void save(ArticleRequestDTO articleDTO) {
         Article articleEntity = Article.toSaveEntity(articleDTO);
         articleRepository.save(articleEntity);
     }
 
+    @Transactional
     public List<ArticleRequestDTO> findAll() {
         List<Article> articleEntityList = articleRepository.findAll();
         List<ArticleRequestDTO> articleDTOList = new ArrayList<>();
@@ -40,13 +41,15 @@ public class ArticleService {
         }
         return articleDTOList;
     }
-  
+
+    @Transactional
     public ArticleRequestDTO findById(Long id) {
         return articleRepository.findById(id)
                 .map(ArticleRequestDTO::toArticleDTO)
                 .orElseThrow(() -> new ArticleNotFoundException());
     }
 
+    @Transactional
     public ArticleRequestDTO update(ArticleUpdateRequestDTO articleDTO) {
         Article articleEntity = Article.toUpdateEntity(articleDTO);
         Article updateArticle = articleRepository.save(articleEntity);
@@ -58,6 +61,7 @@ public class ArticleService {
         articleRepository.deleteById(id);
     }
 
+    @Transactional
     public Page<ArticleRequestDTO> paging(Pageable pageable) {
         int page = pageable.getPageNumber() - 1; // page 위치에 있는 값은 0부터 시작한다.
         int pageLimit = 3; // 한 페이지에 보여줄 글 갯수

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -24,7 +24,7 @@ public class ArticleService {
 
     private final ArticleRepository articleRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void save(ArticleRequestDTO articleDTO) {
         Article articleEntity = Article.toSaveEntity(articleDTO);
         articleRepository.save(articleEntity);
@@ -48,14 +48,14 @@ public class ArticleService {
                 .orElseThrow(() -> new ArticleNotFoundException());
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ArticleRequestDTO update(ArticleUpdateRequestDTO articleDTO) {
         Article articleEntity = Article.toUpdateEntity(articleDTO);
         Article updateArticle = articleRepository.save(articleEntity);
         return findById(updateArticle.getId());
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void delete(Long id) {
         articleRepository.deleteById(id);
     }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -7,6 +7,10 @@ import dev.linkcentral.service.dto.request.ArticleRequestDTO;
 import dev.linkcentral.service.dto.request.ArticleUpdateRequestDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -50,5 +54,20 @@ public class ArticleService {
 
     public void delete(Long id) {
         articleRepository.deleteById(id);
+    }
+
+    public Page<ArticleRequestDTO> paging(Pageable pageable) {
+        int page = pageable.getPageNumber() - 1; // page 위치에 있는 값은 0부터 시작한다.
+        int pageLimit = 3; // 한 페이지에 보여줄 글 갯수
+
+        // 한페이지당 3개씩 글을 보여주고 정렬 기준은 id 기준으로 내림차순 정렬
+        Page<Article> articleEntity = articleRepository.findAll(PageRequest
+                .of(page, pageLimit, Sort.by(Sort.Direction.DESC, "id")));
+
+        return articleEntity.map(article -> new ArticleRequestDTO(
+                article.getId(),
+                article.getWriter(),
+                article.getTitle(),
+                article.getCreatedAt()));
     }
 }

--- a/src/main/java/dev/linkcentral/service/ArticleService.java
+++ b/src/main/java/dev/linkcentral/service/ArticleService.java
@@ -20,18 +20,17 @@ import java.util.List;
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void save(ArticleRequestDTO articleDTO) {
         Article articleEntity = Article.toSaveEntity(articleDTO);
         articleRepository.save(articleEntity);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public List<ArticleRequestDTO> findAll() {
         List<Article> articleEntityList = articleRepository.findAll();
         List<ArticleRequestDTO> articleDTOList = new ArrayList<>();
@@ -42,26 +41,26 @@ public class ArticleService {
         return articleDTOList;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ArticleRequestDTO findById(Long id) {
         return articleRepository.findById(id)
                 .map(ArticleRequestDTO::toArticleDTO)
                 .orElseThrow(() -> new ArticleNotFoundException());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ArticleRequestDTO update(ArticleUpdateRequestDTO articleDTO) {
         Article articleEntity = Article.toUpdateEntity(articleDTO);
         Article updateArticle = articleRepository.save(articleEntity);
         return findById(updateArticle.getId());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void delete(Long id) {
         articleRepository.deleteById(id);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<ArticleRequestDTO> paging(Pageable pageable) {
         int page = pageable.getPageNumber() - 1; // page 위치에 있는 값은 0부터 시작한다.
         int pageLimit = 3; // 한 페이지에 보여줄 글 갯수

--- a/src/main/java/dev/linkcentral/service/MemberService.java
+++ b/src/main/java/dev/linkcentral/service/MemberService.java
@@ -28,7 +28,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JavaMailSender mailSender;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Member joinMember(MemberSaveRequestDTO memberDTO) {
         String nickname = memberDTO.getNickname();
         checkForDuplicate(memberDTO, nickname);
@@ -114,7 +114,7 @@ public class MemberService {
     /**
      * 이메일로 발송된 임시비밀번호로 해당 유저의 패스워드 변경
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public void updatePassword(String generatedPassword, String userEmail) {
         String passwordHash = passwordEncoder.encode(generatedPassword);
         Optional<Member> member = memberRepository.findByEmailAndDeletedFalse(userEmail);
@@ -154,7 +154,7 @@ public class MemberService {
         mailSender.send(message);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void updateMember(MemberEditRequestDTO memberEditDTO) {
         Member memberEntity = memberRepository.findById(memberEditDTO.getId())
                 .orElseThrow(() -> new IllegalArgumentException("회원 찾기 실패"));
@@ -176,7 +176,7 @@ public class MemberService {
         return false;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public boolean deleteMember(String nickname, String password) {
         Member member = memberRepository.findByNicknameAndDeletedFalse(nickname)
                 .orElseThrow(() -> new IllegalArgumentException("닉네임이 존재하지 않습니다."));

--- a/src/main/java/dev/linkcentral/service/MemberService.java
+++ b/src/main/java/dev/linkcentral/service/MemberService.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MemberService {
 
     private static final String FROM_ADDRESS = "alstjr706@gmail.com";
@@ -29,7 +28,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JavaMailSender mailSender;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Member joinMember(MemberSaveRequestDTO memberDTO) {
         String nickname = memberDTO.getNickname();
         checkForDuplicate(memberDTO, nickname);
@@ -63,7 +62,7 @@ public class MemberService {
         }
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Optional<Member> loginMember(String email, String password) {
         Optional<Member> member = memberRepository.findByEmailAndDeletedFalse(email);
         if (member.isPresent()) {
@@ -76,7 +75,7 @@ public class MemberService {
         return Optional.empty();
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean isNicknameDuplicated(String nickname) {
         boolean isDuplicated = memberRepository.existsByNicknameAndDeletedFalse(nickname);
 
@@ -86,7 +85,7 @@ public class MemberService {
         return isDuplicated;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean userEmailCheck(String userEmail, String userName) {
         Optional<Member> member = memberRepository.findByEmailAndNameAndDeletedFalse(userEmail, userName);
 
@@ -99,7 +98,6 @@ public class MemberService {
     /**
      * DTO에 사용자가 원하는 내용과 제목을 저장
      */
-    @Transactional
     public MemberMailRequestDTO createMailAndChangePassword(String userEmail, String userName) {
         MemberMailRequestDTO dto = new MemberMailRequestDTO();
         String generatedPassword = generateTempPassword();
@@ -116,7 +114,7 @@ public class MemberService {
     /**
      * 이메일로 발송된 임시비밀번호로 해당 유저의 패스워드 변경
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public void updatePassword(String generatedPassword, String userEmail) {
         String passwordHash = passwordEncoder.encode(generatedPassword);
         Optional<Member> member = memberRepository.findByEmailAndDeletedFalse(userEmail);
@@ -146,7 +144,6 @@ public class MemberService {
     /**
      * 메일 보내기
      */
-    @Transactional
     public void mailSend(MemberMailRequestDTO mailDto) {
         SimpleMailMessage message = new SimpleMailMessage();
 
@@ -157,7 +154,7 @@ public class MemberService {
         mailSender.send(message);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void updateMember(MemberEditRequestDTO memberEditDTO) {
         Member memberEntity = memberRepository.findById(memberEditDTO.getId())
                 .orElseThrow(() -> new IllegalArgumentException("회원 찾기 실패"));
@@ -168,7 +165,7 @@ public class MemberService {
         memberEntity.updateNickname(memberEditDTO.getNickname());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean checkPassword(String nickname, String password) {
         Optional<Member> member = memberRepository.findByNicknameAndDeletedFalse(nickname);
 
@@ -179,7 +176,7 @@ public class MemberService {
         return false;
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean deleteMember(String nickname, String password) {
         Member member = memberRepository.findByNicknameAndDeletedFalse(nickname)
                 .orElseThrow(() -> new IllegalArgumentException("닉네임이 존재하지 않습니다."));

--- a/src/main/java/dev/linkcentral/service/MemberService.java
+++ b/src/main/java/dev/linkcentral/service/MemberService.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private static final String FROM_ADDRESS = "alstjr706@gmail.com";
@@ -28,6 +29,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JavaMailSender mailSender;
 
+    @Transactional
     public Member joinMember(MemberSaveRequestDTO memberDTO) {
         String nickname = memberDTO.getNickname();
         checkForDuplicate(memberDTO, nickname);
@@ -61,6 +63,7 @@ public class MemberService {
         }
     }
 
+    @Transactional
     public Optional<Member> loginMember(String email, String password) {
         Optional<Member> member = memberRepository.findByEmailAndDeletedFalse(email);
         if (member.isPresent()) {
@@ -73,6 +76,7 @@ public class MemberService {
         return Optional.empty();
     }
 
+    @Transactional
     public boolean isNicknameDuplicated(String nickname) {
         boolean isDuplicated = memberRepository.existsByNicknameAndDeletedFalse(nickname);
 
@@ -82,6 +86,7 @@ public class MemberService {
         return isDuplicated;
     }
 
+    @Transactional
     public boolean userEmailCheck(String userEmail, String userName) {
         Optional<Member> member = memberRepository.findByEmailAndNameAndDeletedFalse(userEmail, userName);
 
@@ -141,6 +146,7 @@ public class MemberService {
     /**
      * 메일 보내기
      */
+    @Transactional
     public void mailSend(MemberMailRequestDTO mailDto) {
         SimpleMailMessage message = new SimpleMailMessage();
 
@@ -151,6 +157,7 @@ public class MemberService {
         mailSender.send(message);
     }
 
+    @Transactional
     public void updateMember(MemberEditRequestDTO memberEditDTO) {
         Member memberEntity = memberRepository.findById(memberEditDTO.getId())
                 .orElseThrow(() -> new IllegalArgumentException("회원 찾기 실패"));
@@ -161,6 +168,7 @@ public class MemberService {
         memberEntity.updateNickname(memberEditDTO.getNickname());
     }
 
+    @Transactional
     public boolean checkPassword(String nickname, String password) {
         Optional<Member> member = memberRepository.findByNicknameAndDeletedFalse(nickname);
 

--- a/src/main/java/dev/linkcentral/service/dto/request/ArticleRequestDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/request/ArticleRequestDTO.java
@@ -32,4 +32,11 @@ public class ArticleRequestDTO {
                 .modifiedAt(article.getModifiedAt())
                 .build();
     }
+
+    public ArticleRequestDTO(Long id, String title, String writer, LocalDateTime createdAt) {
+        this.id = id;
+        this.title = title;
+        this.writer = writer;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/webapp/WEB-INF/views/articles/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/detail.jsp
@@ -1,5 +1,6 @@
 <%@ page import="dev.linkcentral.service.dto.request.ArticleRequestDTO" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -24,7 +25,7 @@
 
         function listReq() {
             console.log("목록 요청");
-            location.href = "/api/v1/article/";
+            location.href = "/api/v1/article/paging?page=${page}";
         }
     </script>
 </head>

--- a/src/main/webapp/WEB-INF/views/articles/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/detail.jsp
@@ -18,14 +18,24 @@
             location.href = "/api/v1/article/update/" + articleId;
         }
 
-        function deleteReq() {
-            console.log("삭제 요청");
-            location.href = "/api/v1/article/delete/" + articleId;
-        }
-
         function listReq() {
             console.log("목록 요청");
             location.href = "/api/v1/article/paging?page=${page}";
+        }
+
+        function deleteReq() {
+            console.log("삭제 요청");
+            $.ajax({
+                url: "/api/v1/article/delete/" + articleId,
+                type: "DELETE",
+                success: function (response) {
+                    alert("게시글이 삭제되었습니다.");
+                    location.href = "/api/v1/article/paging?page=${page}";
+                },
+                error: function(error) {
+                    alert("삭제 중 오류가 발생했습니다: " + error);
+                }
+            });
         }
     </script>
 </head>

--- a/src/main/webapp/WEB-INF/views/articles/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/detail.jsp
@@ -14,27 +14,17 @@
 
         function updateReq() {
             console.log("수정 요청");
-            location.href = "/article/update/" + articleId;
-        }
-
-        function listReq() {
-            console.log("목록 요청");
-            location.href = "/article/";
+            location.href = "/api/v1/article/update/" + articleId;
         }
 
         function deleteReq() {
             console.log("삭제 요청");
-            $.ajax({
-                url: "/article/delete/" + articleId,
-                type: "DELETE",
-                success: function (response) {
-                    alert("게시글이 삭제되었습니다.");
-                    location.href = "/article/";
-                },
-                error: function(error) {
-                    alert("삭제 중 오류가 발생했습니다: " + error);
-                }
-            });
+            location.href = "/api/v1/article/delete/" + articleId;
+        }
+
+        function listReq() {
+            console.log("목록 요청");
+            location.href = "/api/v1/article/";
         }
     </script>
 </head>

--- a/src/main/webapp/WEB-INF/views/articles/list.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/list.jsp
@@ -23,7 +23,7 @@
 
       <td><c:out value="${article.writer}"/></td>
 
-      <td><a href="<c:url value='/article/${article.id}'/>"><c:out value="${article.title}"/></a></td>
+      <td><a href="<c:url value='/api/v1/article/${article.id}'/>"><c:out value="${article.title}"/></a></td>
 
       <td><c:out value="${article.createdAt}"/></td>
 

--- a/src/main/webapp/WEB-INF/views/articles/paging.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/paging.jsp
@@ -1,0 +1,83 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ page import="java.time.format.DateTimeFormatter" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+<button onclick="saveReq()">글작성</button>
+
+<table>
+  <tr>
+    <th>id</th>
+    <th>title</th>
+    <th>writer</th>
+    <th>date</th>
+  </tr>
+  <c:if test="${not empty articleList}">
+    <c:forEach items="${articleList}" var="article">
+      <tr>
+        <td>${article.id}</td>
+        <td><a href="/api/v1/article/${article.id}?page=${articlePage.number + 1}">${article.title}</a></td>
+        <td>${article.writer}</td>
+        <td>${article.createdAt}</td>
+      </tr>
+    </c:forEach>
+  </c:if>
+  <c:if test="${empty articleList}">
+    <tr>
+      <td colspan="5">게시글이 없습니다.</td>
+    </tr>
+  </c:if>
+</table>
+
+<a href="/api/v1/article/paging?page=1">처음 페이지</a>
+
+<!-- 이전 페이지 링크 -->
+<c:choose>
+  <c:when test="${articlePage.number eq 0}">
+    <a href="#">이전</a>
+  </c:when>
+  <c:otherwise>
+    <a href="/api/v1/article/paging?page=${articlePage.number}">이전</a>
+  </c:otherwise>
+</c:choose>
+
+
+<!-- 페이지 번호 링크 -->
+<c:forEach begin="${startPage}" end="${endPage}" var="page">
+  <c:choose>
+    <c:when test="${page eq articlePage.number + 1}">
+      <span>${page}</span>
+    </c:when>
+    <c:otherwise>
+      <a href="/api/v1/article/paging?page=${page}">${page}</a>
+    </c:otherwise>
+  </c:choose>
+</c:forEach>
+
+
+<!-- 다음 페이지 링크 -->
+<c:choose>
+  <c:when test="${articlePage.number + 1 eq articlePage.totalPages}">
+    <a href="#">다음</a>
+  </c:when>
+  <c:otherwise>
+    <a href="/api/v1/article/paging?page=${articlePage.number + 2}">다음</a>
+  </c:otherwise>
+</c:choose>
+
+
+<!-- 마지막 페이지 링크 -->
+<a href="/api/v1/article/paging?page=${articlePage.totalPages}">마지막 페이지</a>
+
+</body>
+<script>
+  function saveReq() {
+    location.href = "/api/v1/article/save";
+  }
+</script>
+</html>

--- a/src/main/webapp/WEB-INF/views/articles/update.jsp
+++ b/src/main/webapp/WEB-INF/views/articles/update.jsp
@@ -28,13 +28,13 @@
       };
 
       $.ajax({
-        url: "/article/update",
+        url: "/api/v1/article/update",
         type: "PUT",
         data: JSON.stringify(data),
         contentType: "application/json",
         success: function(response) {
           console.log("글이 업데이트되었습니다.");
-          location.href = "/article/";
+          location.href = "/api/v1/article/";
         },
         error: function(error) {
           console.error("글 업데이트 중 오류가 발생했습니다.");

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -70,11 +70,11 @@
         }
 
         function studyRecruitmentArticleList() {
-            window.location.href = "/article/";
+            window.location.href = "/api/v1/article/";
         }
 
-        function studyRecruitmentArticleList() {
-            window.location.href = "/article/";
+        function studyRecruitmentArticlePaging() {
+            window.location.href = "/api/v1/article/paging";
         }
     </script>
 
@@ -108,6 +108,8 @@
 <button onclick="studyRecruitmentArticle()">스터디 모집 게시판 글등록</button>
 
 <button onclick="studyRecruitmentArticleList()">스터디 모집 게시판 글목록</button>
+
+<button onclick="studyRecruitmentArticlePaging()">스터디 모집 게시판 페이징목록</button>
 
 
 </body>

--- a/src/main/webapp/WEB-INF/views/home.jsp
+++ b/src/main/webapp/WEB-INF/views/home.jsp
@@ -69,10 +69,6 @@
             window.location.href = "/api/v1/article/save";
         }
 
-        function studyRecruitmentArticleList() {
-            window.location.href = "/api/v1/article/";
-        }
-
         function studyRecruitmentArticlePaging() {
             window.location.href = "/api/v1/article/paging";
         }
@@ -100,14 +96,9 @@
 <p>처음이신가요? 회원가입은 여기서 해주세요!</p>
 <a class="signup-button" href="/members/join-form">회원가입하기</a>
 
-<!-- 비밀번호 찾기 버튼 추가 -->
 <a class="password-reset-button" href="/reset-password">비밀번호 찾기</a>
 
-
-
 <button onclick="studyRecruitmentArticle()">스터디 모집 게시판 글등록</button>
-
-<button onclick="studyRecruitmentArticleList()">스터디 모집 게시판 글목록</button>
 
 <button onclick="studyRecruitmentArticlePaging()">스터디 모집 게시판 페이징목록</button>
 


### PR DESCRIPTION
## 요약
게시판 페이징 기능을 구현하여 사용자가 게시글을 효율적으로 탐색할 수 있게 했습니다. 
특히, Offset 방법을 사용한 페이징 처리 로직을 추가했습니다.

## 더 자세히
- Offset 방법을 사용하여 사용자 요청에 따라 페이지별로 게시글을 나누어 표시합니다.
- 사용자가 페이지 번호를 클릭하여 다른 페이지의 게시글을 볼 수 있는 인터페이스를 구현했습니다.
- 기존 게시글 목록 API를 수정하여 페이징 처리를 지원하도록 개선했습니다.

## 체크리스트
- [X] 페이징 처리가 사용자의 입력에 따라 정확하게 작동하는지 확인
- [X] 프론트엔드 페이지가 사용자 편의성적으로 구현되었는지 검토
- [X] 모든 변경사항에 대해 실행하여 기능이 정상적으로 동작하는지 확인