### PR TITLE
[#97] 그룹 피드 댓글 기능 구현

### DIFF
--- a/src/main/java/dev/linkcentral/database/entity/GroupFeedComment.java
+++ b/src/main/java/dev/linkcentral/database/entity/GroupFeedComment.java
@@ -1,5 +1,6 @@
 package dev.linkcentral.database.entity;
 
+import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentDTO;
 import lombok.Getter;
 
 import javax.persistence.*;
@@ -32,5 +33,14 @@ public class GroupFeedComment extends AuditingFields {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public static GroupFeedComment createComment(GroupFeed groupFeed, Member member, GroupFeedCommentDTO commentDTO) {
+        GroupFeedComment comment = new GroupFeedComment();
+        comment.groupFeed = groupFeed;
+        comment.member = member;
+        comment.content = commentDTO.getContent();
+        comment.writerNickname = member.getNickname();
+        return comment;
     }
 }

--- a/src/main/java/dev/linkcentral/database/repository/GroupFeedCommentRepository.java
+++ b/src/main/java/dev/linkcentral/database/repository/GroupFeedCommentRepository.java
@@ -1,0 +1,11 @@
+package dev.linkcentral.database.repository;
+
+import dev.linkcentral.database.entity.GroupFeedComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupFeedCommentRepository extends JpaRepository<GroupFeedComment, Long> {
+
+    List<GroupFeedComment> findByGroupFeedId(Long groupFeedId);
+}

--- a/src/main/java/dev/linkcentral/presentation/controller/api/closed/GroupFeedController.java
+++ b/src/main/java/dev/linkcentral/presentation/controller/api/closed/GroupFeedController.java
@@ -1,11 +1,9 @@
 package dev.linkcentral.presentation.controller.api.closed;
 
+import dev.linkcentral.presentation.request.groupfeed.GroupFeedCommentRequest;
 import dev.linkcentral.presentation.request.groupfeed.GroupFeedCreateRequest;
 import dev.linkcentral.presentation.request.groupfeed.GroupFeedUpdateRequest;
-import dev.linkcentral.presentation.response.groupfeed.GroupFeedCreateResponse;
-import dev.linkcentral.presentation.response.groupfeed.GroupFeedInfoResponse;
-import dev.linkcentral.presentation.response.groupfeed.GroupFeedListResponse;
-import dev.linkcentral.presentation.response.groupfeed.MyFeedListResponse;
+import dev.linkcentral.presentation.response.groupfeed.*;
 import dev.linkcentral.service.dto.groupfeed.*;
 import dev.linkcentral.service.dto.member.MemberCurrentDTO;
 import dev.linkcentral.service.facade.GroupFeedFacade;
@@ -81,5 +79,20 @@ public class GroupFeedController {
         GroupFeedUpdateDTO feedUpdateDTO = GroupFeedUpdateRequest.toGroupFeedUpdateCommand(feedId, groupFeedUpdateRequest);
         groupFeedFacade.updateGroupFeed(feedUpdateDTO);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{feedId}/comments")
+    public ResponseEntity<Void> createGroupFeedComment(@PathVariable Long feedId,
+                                                       @Validated @RequestBody GroupFeedCommentRequest commentRequest) {
+        GroupFeedCommentDTO feedCommentDTO = GroupFeedCommentRequest.toGroupFeedCommentCommand(commentRequest);
+        groupFeedFacade.addComment(feedId, feedCommentDTO);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{feedId}/comments")
+    public ResponseEntity<GroupFeedCommentResponse> getComments(@PathVariable Long feedId) {
+        List<GroupFeedCommentDTO> comments = groupFeedFacade.getComments(feedId);
+        GroupFeedCommentResponse response = GroupFeedCommentResponse.toGroupFeedCommentResponse(comments);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/dev/linkcentral/presentation/request/groupfeed/GroupFeedCommentRequest.java
+++ b/src/main/java/dev/linkcentral/presentation/request/groupfeed/GroupFeedCommentRequest.java
@@ -1,0 +1,20 @@
+package dev.linkcentral.presentation.request.groupfeed;
+
+import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentDTO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupFeedCommentRequest {
+
+    private String content;
+
+    public static GroupFeedCommentDTO toGroupFeedCommentCommand(GroupFeedCommentRequest commentRequest) {
+        return GroupFeedCommentDTO.builder()
+                .content(commentRequest.getContent())
+                .build();
+    }
+}

--- a/src/main/java/dev/linkcentral/presentation/response/groupfeed/GroupFeedCommentResponse.java
+++ b/src/main/java/dev/linkcentral/presentation/response/groupfeed/GroupFeedCommentResponse.java
@@ -1,0 +1,24 @@
+package dev.linkcentral.presentation.response.groupfeed;
+
+import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupFeedCommentResponse {
+
+    private List<GroupFeedCommentDTO> comments;
+
+    public static GroupFeedCommentResponse toGroupFeedCommentResponse(List<GroupFeedCommentDTO> comments) {
+        return GroupFeedCommentResponse.builder()
+                .comments(comments)
+                .build();
+    }
+}

--- a/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedCommentDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedCommentDTO.java
@@ -1,0 +1,18 @@
+package dev.linkcentral.service.dto.groupfeed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupFeedCommentDTO {
+
+    private Long id;
+    private String writerNickname;
+    private String content;
+    private String createdAt;
+}

--- a/src/main/java/dev/linkcentral/service/facade/GroupFeedFacade.java
+++ b/src/main/java/dev/linkcentral/service/facade/GroupFeedFacade.java
@@ -52,4 +52,13 @@ public class GroupFeedFacade {
         Member currentMember = memberService.getCurrentMember();
         groupFeedService.updateGroupFeed(currentMember.getId(), groupFeedUpdateDTO);
     }
+
+    public void addComment(Long feedId, GroupFeedCommentDTO feedCommentDTO) {
+        Member member = memberService.getCurrentMember();
+        groupFeedService.addComment(feedId, feedCommentDTO, member);
+    }
+
+    public List<GroupFeedCommentDTO> getComments(Long feedId) {
+        return groupFeedService.getComments(feedId);
+    }
 }

--- a/src/main/java/dev/linkcentral/service/mapper/GroupFeedMapper.java
+++ b/src/main/java/dev/linkcentral/service/mapper/GroupFeedMapper.java
@@ -1,8 +1,10 @@
 package dev.linkcentral.service.mapper;
 
 import dev.linkcentral.database.entity.GroupFeed;
+import dev.linkcentral.database.entity.GroupFeedComment;
 import dev.linkcentral.database.entity.Member;
 import dev.linkcentral.database.entity.Profile;
+import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentDTO;
 import dev.linkcentral.service.dto.groupfeed.GroupFeedSavedDTO;
 import dev.linkcentral.service.dto.groupfeed.GroupFeedWithProfileDTO;
 import dev.linkcentral.service.dto.groupfeed.MyGroupFeedDetailsDTO;
@@ -52,5 +54,14 @@ public class GroupFeedMapper {
                 .createdAt(groupFeed.getCreatedAt())
                 .profileImageUrl(profile != null ? profile.getImageUrl() : null)
                 .build();
+    }
+
+    public GroupFeedCommentDTO toGroupFeedCommentDTO(GroupFeedComment comment) {
+        return new GroupFeedCommentDTO(
+                comment.getId(),
+                comment.getWriterNickname(),
+                comment.getContent(),
+                comment.getCreatedAt().toString()
+        );
     }
 }

--- a/src/main/webapp/WEB-INF/views/groupfeed/view.jsp
+++ b/src/main/webapp/WEB-INF/views/groupfeed/view.jsp
@@ -37,8 +37,6 @@
             margin-bottom: 20px;
             border-radius: 8px;
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-            max-width: 680px;
-            margin: 0 auto 20px;
         }
 
         .feed-item img.feed-image {
@@ -63,10 +61,6 @@
             align-items: center;
             margin-bottom: 10px;
             justify-content: space-between;
-        }
-
-        .feed-content {
-            margin-right: 20px;
         }
 
         .writer-details {
@@ -116,6 +110,52 @@
             text-align: right;
             margin-top: 10px;
         }
+
+        .comments-section {
+            margin-top: 20px;
+        }
+
+        .comment-item {
+            padding: 10px;
+        }
+
+        .comment-writer {
+            font-weight: bold;
+        }
+
+        .comment-inline {
+            display: flex;
+            justify-content: flex-start;
+            align-items: center;
+            margin-bottom: -24px;
+        }
+
+        h4, .h4 {
+            color: #007bff;
+            font-size: 1.4em;
+            border-bottom: 2px solid #007bff;
+            padding-bottom: 5px;
+        }
+
+        .form-group {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+        }
+
+        .form-group textarea {
+            flex-grow: 1;
+            margin-top: 10px;
+            margin-right: 10px;
+        }
+
+        .form-group button {
+            height: 60px;
+            width: 11%;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
     </style>
 
     <script>
@@ -127,11 +167,11 @@
                     'Authorization': 'Bearer ' + localStorage.getItem("jwt")
                 },
                 success: function (response) {
-                    if (response.memberId === null || response.memberId === '') {
+                    if (!response.memberId) {
                         alert('회원 ID가 존재하지 않습니다.');
                         return;
                     }
-                    const memberId  = response.memberId;
+                    const memberId = response.memberId;
                     window.location.href = "/api/v1/view/profile/view?memberId=" + memberId;
                 },
                 error: function (xhr, status, error) {
@@ -177,8 +217,17 @@
                                 (feed.imageUrl ? '<img src="' + feed.imageUrl + '" alt="Feed Image" class="feed-image">' : '') +
                                 '<p class="feed-content">' + feed.content + '</p>' +
                                 '<p class="feed-created"><small>' + new Date(feed.createdAt).toLocaleString() + '</small></p>' +
+                                '<div class="comments-section" id="comments-section-' + feed.id + '">' +
+                                '<h4>댓글</h4>' +
+                                '<div id="comments-' + feed.id + '"></div>' +
+                                '<div class="form-group">' +
+                                '<textarea id="comment-input-' + feed.id + '" class="form-control" rows="2" placeholder="댓글을 입력하세요"></textarea>' +
+                                '<button class="btn btn-primary mt-2" onclick="postComment(' + feed.id + ')">댓글 작성</button>' +
+                                '</div>' +
+                                '</div>' +
                                 '</div>';
                             $('#feedContainer').append(feedHtml);
+                            loadComments(feed.id);
                         });
                         currentPage++;
                         if (feeds.length < pageSize) {
@@ -194,6 +243,60 @@
                 complete: function() {
                     isLoading = false;
                     $('#loadingSpinner').hide();
+                }
+            });
+        }
+
+        function loadComments(feedId) {
+            $.ajax({
+                url: '/api/v1/group-feed/' + feedId + '/comments',
+                method: 'GET',
+                headers: {
+                    'Authorization': 'Bearer ' + localStorage.getItem("jwt")
+                },
+                success: function(response) {
+                    const comments = response.comments;
+                    const commentsContainer = $('#comments-' + feedId);
+                    commentsContainer.empty();
+                    comments.forEach(comment => {
+                        const commentHtml =
+                            '<div class="comment-item">' +
+                            '<div class="comment-inline">' +
+                            '<p class="comment-writer">' + comment.writerNickname + ':&nbsp;</p>' +
+                            '<p class="comment-content">' + comment.content + '</p>' +
+                            '<p class="comment-created" style="margin-left: auto;"><small>' + new Date(comment.createdAt).toLocaleString() + '</small></p>' +
+                            '</div>' +
+                            '</div>';
+                        commentsContainer.append(commentHtml);
+                    });
+                },
+                error: function(xhr) {
+                    console.error('Failed to load comments:', xhr.responseText);
+                }
+            });
+        }
+
+        function postComment(feedId) {
+            const content = $('#comment-input-' + feedId).val();
+            if (!content) {
+                alert('댓글을 입력하세요.');
+                return;
+            }
+
+            $.ajax({
+                url: '/api/v1/group-feed/' + feedId + '/comments',
+                method: 'POST',
+                contentType: 'application/json',
+                data: JSON.stringify({ content: content }),
+                headers: {
+                    'Authorization': 'Bearer ' + localStorage.getItem("jwt")
+                },
+                success: function() {
+                    $('#comment-input-' + feedId).val('');
+                    loadComments(feedId);
+                },
+                error: function(xhr) {
+                    console.error('Failed to post comment:', xhr.responseText);
                 }
             });
         }
@@ -232,7 +335,17 @@
                     <!-- No image available -->
                 </c:otherwise>
             </c:choose>
-            <p><small>작성자: ${feed.writer}</small></p>
+            <p class="feed-created"><small>작성자: ${feed.writer}</small></p>
+            <div class="comments-section" id="comments-section-${feed.id}">
+                <h4>댓글</h4>
+                <div id="comments-${feed.id}"></div>
+                <div class="form-group">
+                    <textarea id="comment-input-${feed.id}" class="form-control" rows="2" placeholder="댓글을 입력하세요"></textarea>
+                    <button class="btn btn-primary">
+                        <span>댓글 작성</span>
+                    </button>
+                </div>
+            </div>
         </div>
     </c:forEach>
 </div>


### PR DESCRIPTION
## 요약
그룹 피드 댓글 기능을 구현하여, 사용자가 피드에 댓글을 작성하고 조회할 수 있도록 했습니다. 
이를 통해 그룹 내에서의 상호작용을 강화하고, 댓글 관리 기능을 제공했습니다.

## 더 자세히
- 사용자가 그룹 피드에 댓글을 작성할 수 있는 기능을 추가했습니다.
- 작성된 댓글을 조회하고, 해당 피드와 연결된 모든 댓글을 가져오는 API를 구현했습니다.
- 댓글 작성 및 조회와 관련된 서비스 로직과 데이터베이스 레포지토리를 구축했습니다.

## 체크리스트
- [X] 댓글 작성 기능이 정상적으로 작동하는지 확인
- [X] 댓글 조회 기능이 올바르게 동작하는지 검증
- [X] 댓글 관리 로직과 데이터베이스 연동이 정확하게 이루어지는지 테스트