### PR TITLE
[#99] 그룹 피드 댓글 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/dev/linkcentral/database/repository/GroupFeedCommentRepository.java
+++ b/src/main/java/dev/linkcentral/database/repository/GroupFeedCommentRepository.java
@@ -4,8 +4,11 @@ import dev.linkcentral.database.entity.GroupFeedComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupFeedCommentRepository extends JpaRepository<GroupFeedComment, Long> {
 
     List<GroupFeedComment> findByGroupFeedId(Long groupFeedId);
+
+    Optional<GroupFeedComment> findByIdAndGroupFeedIdAndMemberId(Long id, Long groupFeedId, Long memberId);
 }

--- a/src/main/java/dev/linkcentral/presentation/controller/api/closed/GroupFeedController.java
+++ b/src/main/java/dev/linkcentral/presentation/controller/api/closed/GroupFeedController.java
@@ -1,6 +1,7 @@
 package dev.linkcentral.presentation.controller.api.closed;
 
 import dev.linkcentral.presentation.request.groupfeed.GroupFeedCommentRequest;
+import dev.linkcentral.presentation.request.groupfeed.GroupFeedCommentUpdateRequest;
 import dev.linkcentral.presentation.request.groupfeed.GroupFeedCreateRequest;
 import dev.linkcentral.presentation.request.groupfeed.GroupFeedUpdateRequest;
 import dev.linkcentral.presentation.response.groupfeed.*;
@@ -83,7 +84,8 @@ public class GroupFeedController {
 
     @PostMapping("/{feedId}/comments")
     public ResponseEntity<Void> createGroupFeedComment(@PathVariable Long feedId,
-                                                       @Validated @RequestBody GroupFeedCommentRequest commentRequest) {
+                                @Validated @RequestBody GroupFeedCommentRequest commentRequest) {
+
         GroupFeedCommentDTO feedCommentDTO = GroupFeedCommentRequest.toGroupFeedCommentCommand(commentRequest);
         groupFeedFacade.addComment(feedId, feedCommentDTO);
         return ResponseEntity.ok().build();
@@ -94,5 +96,21 @@ public class GroupFeedController {
         List<GroupFeedCommentDTO> comments = groupFeedFacade.getComments(feedId);
         GroupFeedCommentResponse response = GroupFeedCommentResponse.toGroupFeedCommentResponse(comments);
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{feedId}/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(@PathVariable Long feedId, @PathVariable Long commentId,
+                                              @Validated @RequestBody GroupFeedCommentUpdateRequest commentUpdateRequest) {
+
+        GroupFeedCommentUpdateDTO commentUpdateDTO = GroupFeedCommentUpdateRequest
+                .toGroupFeedCommentUpdateCommand(feedId, commentId, commentUpdateRequest);
+        groupFeedFacade.updateComment(commentUpdateDTO);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{feedId}/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable Long feedId, @PathVariable Long commentId) {
+        groupFeedFacade.deleteComment(feedId, commentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/dev/linkcentral/presentation/request/groupfeed/GroupFeedCommentRequest.java
+++ b/src/main/java/dev/linkcentral/presentation/request/groupfeed/GroupFeedCommentRequest.java
@@ -1,15 +1,24 @@
 package dev.linkcentral.presentation.request.groupfeed;
 
 import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentDTO;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description = "피드 댓글 작성을 위한 요청 데이터 모델")
 public class GroupFeedCommentRequest {
 
+    @ApiModelProperty(value = "게시글의 내용", required = true)
+    @NotBlank(message = "게시글 내용은 필수 입력 항목입니다.")
+    @Size(min = 3, max = 10000, message = "게시글 내용은 3자 이상 10000자 이하이어야 합니다.")
     private String content;
 
     public static GroupFeedCommentDTO toGroupFeedCommentCommand(GroupFeedCommentRequest commentRequest) {

--- a/src/main/java/dev/linkcentral/presentation/request/groupfeed/GroupFeedCommentUpdateRequest.java
+++ b/src/main/java/dev/linkcentral/presentation/request/groupfeed/GroupFeedCommentUpdateRequest.java
@@ -1,0 +1,36 @@
+package dev.linkcentral.presentation.request.groupfeed;
+
+import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentUpdateDTO;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@ApiModel(description = "피드 댓글 수정을 위한 요청 데이터 모델")
+public class GroupFeedCommentUpdateRequest {
+
+    private Long feedId;
+    private Long commentId;
+
+    @ApiModelProperty(value = "게시글의 내용", required = true)
+    @NotBlank(message = "게시글 내용은 필수 입력 항목입니다.")
+    @Size(min = 3, max = 10000, message = "게시글 내용은 3자 이상 10000자 이하이어야 합니다.")
+    private String content;
+
+    public static GroupFeedCommentUpdateDTO toGroupFeedCommentUpdateCommand(
+            Long feedId, Long commentId, GroupFeedCommentUpdateRequest commentUpdateRequest) {
+
+        GroupFeedCommentUpdateDTO updateRequest = new GroupFeedCommentUpdateDTO();
+        updateRequest.setFeedId(feedId);
+        updateRequest.setCommentId(commentId);
+        updateRequest.setContent(commentUpdateRequest.getContent());
+        return updateRequest;
+    }
+}

--- a/src/main/java/dev/linkcentral/service/GroupFeedService.java
+++ b/src/main/java/dev/linkcentral/service/GroupFeedService.java
@@ -121,4 +121,21 @@ public class GroupFeedService {
                 .map(groupFeedMapper::toGroupFeedCommentDTO)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void updateComment(Member member, GroupFeedCommentUpdateDTO commentUpdateDTO) {
+        GroupFeedComment comment = groupFeedCommentRepository.findByIdAndGroupFeedIdAndMemberId(
+                        commentUpdateDTO.getCommentId(), commentUpdateDTO.getFeedId(), member.getId())
+                        .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없거나 수정할 권한이 없습니다."));
+        comment.updateContent(commentUpdateDTO.getContent());
+        groupFeedCommentRepository.save(comment);
+    }
+
+    @Transactional
+    public void deleteComment(Long feedId, Long commentId, Member member) {
+        GroupFeedComment comment = groupFeedCommentRepository
+                .findByIdAndGroupFeedIdAndMemberId(commentId, feedId, member.getId())
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없거나 삭제할 권한이 없습니다."));
+        groupFeedCommentRepository.delete(comment);
+    }
 }

--- a/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedCommentUpdateDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedCommentUpdateDTO.java
@@ -1,0 +1,15 @@
+package dev.linkcentral.service.dto.groupfeed;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupFeedCommentUpdateDTO {
+
+    private Long feedId;
+    private Long commentId;
+    private String content;
+}

--- a/src/main/java/dev/linkcentral/service/facade/GroupFeedFacade.java
+++ b/src/main/java/dev/linkcentral/service/facade/GroupFeedFacade.java
@@ -61,4 +61,14 @@ public class GroupFeedFacade {
     public List<GroupFeedCommentDTO> getComments(Long feedId) {
         return groupFeedService.getComments(feedId);
     }
+
+    public void updateComment(GroupFeedCommentUpdateDTO commentUpdateDTO) {
+        Member member = memberService.getCurrentMember();
+        groupFeedService.updateComment(member, commentUpdateDTO);
+    }
+
+    public void deleteComment(Long feedId, Long commentId) {
+        Member member = memberService.getCurrentMember();
+        groupFeedService.deleteComment(feedId, commentId, member);
+    }
 }


### PR DESCRIPTION
## 요약
그룹 피드 댓글의 수정 및 삭제 기능을 구현했습니다. 
이를 통해 사용자는 작성한 댓글을 수정하거나 삭제할 수 있으며, 
관련된 API와 비즈니스 로직, 그리고 프론트엔드 페이지가 추가되었습니다.

## 더 자세히
- 댓글을 수정하거나 삭제할 수 있는 RESTful API를 개발했습니다.
- 댓글 수정 및 삭제 기능을 처리하는 서비스 계층의 비즈니스 로직을 구현했습니다.
- 사용자가 쉽게 댓글을 수정 및 삭제할 수 있도록 관련 UI를 업데이트했습니다.

## 체크리스트
- [X] 댓글 수정 및 삭제 기능이 정상적으로 작동하는지 테스트
- [X] API 요청이 예상대로 처리되는지 확인
- [X] 프론트엔드 UI가 올바르게 반영되는지 검증