### PR TITLE
[#101] 그룹 피드 좋아요 기능 구현

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -21,3 +21,4 @@
 - GroupFeedService가 ProfileRepository에 직접 의존하게 되므로, 서비스 클래스의 결합도가 높아져 있는 상태이다.
     - GroupFeedService가 ProfileService를 의존하도록 하자. (생성자 주입 관련)
     - 다른 코드도 이런식으로 결합도가 높아져 있는 상황
+- 나의 피드에 대해서 수정/삭제를 진행하는데, 다른 유저로 로그인 하여도 수정/삭제 기능이 가능하다.

--- a/src/main/java/dev/linkcentral/database/entity/GroupFeedLike.java
+++ b/src/main/java/dev/linkcentral/database/entity/GroupFeedLike.java
@@ -1,11 +1,13 @@
 package dev.linkcentral.database.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.persistence.*;
 
 @Getter
 @Entity
+@AllArgsConstructor
 public class GroupFeedLike extends AuditingFields {
 
     @Id
@@ -20,6 +22,25 @@ public class GroupFeedLike extends AuditingFields {
     @JoinColumn(name = "group_feed_id")
     private GroupFeed groupFeed;
 
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     protected GroupFeedLike() {
+    }
+
+    public static GroupFeedLike createGroupFeedLike(GroupFeed groupFeed, Member member) {
+        GroupFeedLike groupFeedLike = new GroupFeedLike();
+        groupFeedLike.updateGroupFeed(groupFeed);
+        groupFeedLike.updateMember(member);
+        return groupFeedLike;
+    }
+
+    public void updateGroupFeed(GroupFeed groupFeed) {
+        this.groupFeed = groupFeed;
+    }
+
+    public void updateMember(Member member) {
+        this.member = member;
     }
 }

--- a/src/main/java/dev/linkcentral/database/entity/GroupFeedStatistic.java
+++ b/src/main/java/dev/linkcentral/database/entity/GroupFeedStatistic.java
@@ -19,18 +19,16 @@ public class GroupFeedStatistic extends AuditingFields {
     @Column(name = "likes")
     private int likes;
 
-    @Column(name = "views")
-    private int views;
-
     protected GroupFeedStatistic() {
     }
 
+    public static GroupFeedStatistic createStatistic(GroupFeed groupFeed) {
+        GroupFeedStatistic statistic = new GroupFeedStatistic();
+        statistic.groupFeed = groupFeed;
+        return statistic;
+    }
 
     public void updateLikes(int like) {
         this.likes = like;
-    }
-
-    public void updateViews(int view) {
-        this.views = view;
     }
 }

--- a/src/main/java/dev/linkcentral/database/repository/GroupFeedCommentRepository.java
+++ b/src/main/java/dev/linkcentral/database/repository/GroupFeedCommentRepository.java
@@ -11,4 +11,6 @@ public interface GroupFeedCommentRepository extends JpaRepository<GroupFeedComme
     List<GroupFeedComment> findByGroupFeedId(Long groupFeedId);
 
     Optional<GroupFeedComment> findByIdAndGroupFeedIdAndMemberId(Long id, Long groupFeedId, Long memberId);
+
+    void deleteByGroupFeedId(Long groupFeedId);
 }

--- a/src/main/java/dev/linkcentral/database/repository/GroupFeedLikeRepository.java
+++ b/src/main/java/dev/linkcentral/database/repository/GroupFeedLikeRepository.java
@@ -1,0 +1,16 @@
+package dev.linkcentral.database.repository;
+
+import dev.linkcentral.database.entity.GroupFeed;
+import dev.linkcentral.database.entity.GroupFeedLike;
+import dev.linkcentral.database.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GroupFeedLikeRepository extends JpaRepository<GroupFeedLike, Long> {
+
+    Optional<GroupFeedLike> findByGroupFeedAndMember(GroupFeed groupFeed, Member member);
+
+    List<GroupFeedLike> findByGroupFeedId(Long groupFeedId);
+}

--- a/src/main/java/dev/linkcentral/database/repository/GroupFeedStatisticRepository.java
+++ b/src/main/java/dev/linkcentral/database/repository/GroupFeedStatisticRepository.java
@@ -1,0 +1,14 @@
+package dev.linkcentral.database.repository;
+
+import dev.linkcentral.database.entity.GroupFeed;
+import dev.linkcentral.database.entity.GroupFeedStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GroupFeedStatisticRepository extends JpaRepository<GroupFeedStatistic, Long> {
+
+    Optional<GroupFeedStatistic> findByGroupFeed(GroupFeed groupFeed);
+
+    void deleteByGroupFeedId(Long groupFeedId);
+}

--- a/src/main/java/dev/linkcentral/presentation/controller/api/closed/GroupFeedController.java
+++ b/src/main/java/dev/linkcentral/presentation/controller/api/closed/GroupFeedController.java
@@ -113,4 +113,11 @@ public class GroupFeedController {
         groupFeedFacade.deleteComment(feedId, commentId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{feedId}/like")
+    public ResponseEntity<GroupFeedLikeResponse> toggleLike(@PathVariable Long feedId) {
+        GroupFeedLikeDTO groupFeedLikeDTO = groupFeedFacade.toggleLike(feedId);
+        GroupFeedLikeResponse response = GroupFeedLikeResponse.toGroupFeedLikeResponse(groupFeedLikeDTO);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/dev/linkcentral/presentation/response/groupfeed/GroupFeedLikeResponse.java
+++ b/src/main/java/dev/linkcentral/presentation/response/groupfeed/GroupFeedLikeResponse.java
@@ -1,0 +1,24 @@
+package dev.linkcentral.presentation.response.groupfeed;
+
+import dev.linkcentral.service.dto.groupfeed.GroupFeedLikeDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupFeedLikeResponse {
+
+    private int likeCount;
+    private boolean liked;
+
+    public static GroupFeedLikeResponse toGroupFeedLikeResponse(GroupFeedLikeDTO groupFeedLikeDTO) {
+        return GroupFeedLikeResponse.builder()
+                .likeCount(groupFeedLikeDTO.getLikeCount())
+                .liked(groupFeedLikeDTO.isLiked())
+                .build();
+    }
+}

--- a/src/main/java/dev/linkcentral/service/ProfileService.java
+++ b/src/main/java/dev/linkcentral/service/ProfileService.java
@@ -37,11 +37,14 @@ public class ProfileService {
         updateProfileDetails(profile, profileDTO.getBio(), imageFile);
     }
 
-    private Profile findOrCreateProfile(Long memberId) {
+    public Profile findOrCreateProfile(Long memberId) {
         return profileRepository.findByMemberId(memberId)
-                .orElseGet(() -> { Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> new EntityNotFoundException("ID로 멤버를 찾을 수 없습니다."));
-                    return new Profile(member, "", "");
+                .orElseGet(() -> {
+                    Member member = memberRepository.findById(memberId)
+                            .orElseThrow(() -> new EntityNotFoundException("ID로 멤버를 찾을 수 없습니다."));
+                    String defaultImageUrl = "/images/default.png"; // 기본 이미지 경로
+                    Profile newProfile = new Profile(member, "자신을 소개해 주세요!", defaultImageUrl);
+                    return profileRepository.save(newProfile);
                 });
     }
 

--- a/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedLikeDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedLikeDTO.java
@@ -1,0 +1,16 @@
+package dev.linkcentral.service.dto.groupfeed;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GroupFeedLikeDTO {
+
+    private int likeCount;
+    private boolean liked;
+}

--- a/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedWithProfileDTO.java
+++ b/src/main/java/dev/linkcentral/service/dto/groupfeed/GroupFeedWithProfileDTO.java
@@ -18,4 +18,5 @@ public class GroupFeedWithProfileDTO {
     private String imageUrl;
     private LocalDateTime createdAt;
     private String profileImageUrl;
+    private int likeCount;
 }

--- a/src/main/java/dev/linkcentral/service/facade/GroupFeedFacade.java
+++ b/src/main/java/dev/linkcentral/service/facade/GroupFeedFacade.java
@@ -71,4 +71,9 @@ public class GroupFeedFacade {
         Member member = memberService.getCurrentMember();
         groupFeedService.deleteComment(feedId, commentId, member);
     }
+
+    public GroupFeedLikeDTO toggleLike(Long feedId) {
+        Long memberId = memberService.getCurrentMember().getId();
+        return groupFeedService.toggleLike(feedId, memberId);
+    }
 }

--- a/src/main/java/dev/linkcentral/service/mapper/GroupFeedMapper.java
+++ b/src/main/java/dev/linkcentral/service/mapper/GroupFeedMapper.java
@@ -4,10 +4,7 @@ import dev.linkcentral.database.entity.GroupFeed;
 import dev.linkcentral.database.entity.GroupFeedComment;
 import dev.linkcentral.database.entity.Member;
 import dev.linkcentral.database.entity.Profile;
-import dev.linkcentral.service.dto.groupfeed.GroupFeedCommentDTO;
-import dev.linkcentral.service.dto.groupfeed.GroupFeedSavedDTO;
-import dev.linkcentral.service.dto.groupfeed.GroupFeedWithProfileDTO;
-import dev.linkcentral.service.dto.groupfeed.MyGroupFeedDetailsDTO;
+import dev.linkcentral.service.dto.groupfeed.*;
 import dev.linkcentral.service.dto.member.MemberCurrentDTO;
 import org.springframework.stereotype.Component;
 
@@ -32,7 +29,7 @@ public class GroupFeedMapper {
                 .build();
     }
 
-    public GroupFeedWithProfileDTO toGroupFeedWithProfileDTO(GroupFeed groupFeed, Profile profile) {
+    public GroupFeedWithProfileDTO toGroupFeedWithProfileDTO(GroupFeed groupFeed, Profile profile, int likeCount) {
         return GroupFeedWithProfileDTO.builder()
                 .id(groupFeed.getId())
                 .title(groupFeed.getTitle())
@@ -41,6 +38,7 @@ public class GroupFeedMapper {
                 .imageUrl(groupFeed.getImageUrl())
                 .createdAt(groupFeed.getCreatedAt())
                 .profileImageUrl(profile != null ? profile.getImageUrl() : null)
+                .likeCount(likeCount)
                 .build();
     }
 
@@ -63,5 +61,12 @@ public class GroupFeedMapper {
                 comment.getContent(),
                 comment.getCreatedAt().toString()
         );
+    }
+
+    public GroupFeedLikeDTO toGroupFeedLikeDTO(int likes, boolean liked) {
+        return GroupFeedLikeDTO.builder()
+                .likeCount(likes)
+                .liked(liked)
+                .build();
     }
 }

--- a/src/main/webapp/WEB-INF/views/groupfeed/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/groupfeed/detail.jsp
@@ -58,6 +58,8 @@
         .feed-content {
             font-size: 1.2em;
             margin-bottom: 20px;
+            word-wrap: break-word;
+            white-space: pre-wrap;
         }
 
         .feed-image {


### PR DESCRIPTION
## 요약
그룹 피드에 대한 좋아요 기능을 구현했습니다. 
사용자는 그룹 피드에 좋아요를 표시하거나 취소할 수 있으며, 
이에 따른 피드백이 실시간으로 반영됩니다.

## 더 자세히
- 사용자가 피드에 좋아요를 누를 수 있는 RESTful API를 개발했습니다.
- 좋아요 데이터의 저장과 관리를 위한 엔터티와 리포지토리를 구현했습니다.
- 사용자 인터페이스에 좋아요 버튼을 추가하고, 좋아요 상태를 실시간으로 표시할 수 있도록 뷰 페이지를 업데이트했습니다.

## 체크리스트
- [X] 좋아요 기능이 정상적으로 작동하는지 테스트
- [X] API 요청과 응답이 정확하게 처리되는지 확인
- [X] 뷰 페이지에서 좋아요 상태가 올바르게 표시되는지 검증